### PR TITLE
Fix typo with AR15 ammo

### DIFF
--- a/Config/items.xml
+++ b/Config/items.xml
@@ -1013,7 +1013,7 @@
 	<property class="Action0">
 		<property name="Class" value="Ranged"/>
 		<property name="Delay" value="0.150"/>
-		<property name="Magazine_items" value="223 Bullet,5.56mm  Bullet"/>
+		<property name="Magazine_items" value="223 Bullet,5.56mm Bullet"/>
 		<property name="Sound_start" value="ar15fire"/>
 		<property name="Sound_empty" value="weapon_empty"/>
 		<property name="Sound_reload" value="ak47_reload"/>


### PR DESCRIPTION
Extra space in 5.56 name meant that 5.56 was not usable by AR15
in-game.